### PR TITLE
support adding ios9 custom waves color

### DIFF
--- a/src/ios9curve.js
+++ b/src/ios9curve.js
@@ -178,8 +178,9 @@ export default class iOS9Curve {
 		this.prevMaxY = maxY;
 	}
 
-	static getDefinition() {
-		return [{
+	static getDefinition(waveColors) {
+		return Object.assign(
+			[{
 				color: "255,255,255",
 				supportLine: true
 			},
@@ -194,8 +195,7 @@ export default class iOS9Curve {
 			{
 				// green
 				color: "48, 220, 155"
-			}
-
-		];
+			}], waveColors
+		);
 	}
 }

--- a/src/siriwave.js
+++ b/src/siriwave.js
@@ -119,7 +119,7 @@ export default class SiriWave {
 
 		// Instantiate all curves based on the style
 		if (this.opt.style === 'ios9') {
-			for (let def of iOS9Curve.getDefinition()) {
+			for (let def of iOS9Curve.getDefinition(this.opt.waveColors || [])) {
 				this.curves.push(new iOS9Curve({
 					ctrl: this,
 					definition: def


### PR DESCRIPTION
Adding ios9 custom waves color.
For example:
```
const siriWave = new SiriWave({
  container: document.getElementById('siriwave'),
  style: 'ios9',
  waveColors: [
    { color: '255, 255, 255', supportLine: true },
    { color: '255, 0, 0' },
    { color: '0, 255, 0' },
    { color: '0, 0, 255' }
  ]
})
```